### PR TITLE
Complete the switch to `libjpeg-turbo`

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,20 +8,20 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_libjpegjpegr_base4.1:
-        CONFIG: linux_64_libjpegjpegr_base4.1
+      linux_64_r_base4.1:
+        CONFIG: linux_64_r_base4.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_libjpeglibjpeg-turbor_base4.2:
-        CONFIG: linux_64_libjpeglibjpeg-turbor_base4.2
+      linux_64_r_base4.2:
+        CONFIG: linux_64_r_base4.2
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_libjpegjpegr_base4.1:
-        CONFIG: linux_ppc64le_libjpegjpegr_base4.1
+      linux_ppc64le_r_base4.1:
+        CONFIG: linux_ppc64le_r_base4.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
-      linux_ppc64le_libjpeglibjpeg-turbor_base4.2:
-        CONFIG: linux_ppc64le_libjpeglibjpeg-turbor_base4.2
+      linux_ppc64le_r_base4.2:
+        CONFIG: linux_ppc64le_r_base4.2
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,11 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_libjpegjpegr_base4.1:
-        CONFIG: osx_64_libjpegjpegr_base4.1
+      osx_64_r_base4.1:
+        CONFIG: osx_64_r_base4.1
         UPLOAD_PACKAGES: 'True'
-      osx_64_libjpeglibjpeg-turbor_base4.2:
-        CONFIG: osx_64_libjpeglibjpeg-turbor_base4.2
+      osx_64_r_base4.2:
+        CONFIG: osx_64_r_base4.2
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_r_base4.1.yaml
+++ b/.ci_support/linux_64_r_base4.1.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -12,8 +12,8 @@ cran_mirror:
 - https://cran.r-project.org
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-libjpeg:
-- jpeg
+libjpeg_turbo:
+- '2'
 pin_run_as_build:
   r-base:
     min_pin: x.x
@@ -22,6 +22,3 @@ r_base:
 - '4.1'
 target_platform:
 - linux-64
-zip_keys:
-- - r_base
-  - libjpeg

--- a/.ci_support/linux_64_r_base4.2.yaml
+++ b/.ci_support/linux_64_r_base4.2.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
-cdt_arch:
-- aarch64
+- '12'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,17 +11,14 @@ channel_targets:
 cran_mirror:
 - https://cran.r-project.org
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
-libjpeg:
-- jpeg
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+libjpeg_turbo:
+- '2'
 pin_run_as_build:
   r-base:
     min_pin: x.x
     max_pin: x.x
 r_base:
-- '4.1'
+- '4.2'
 target_platform:
-- linux-aarch64
-zip_keys:
-- - r_base
-  - libjpeg
+- linux-64

--- a/.ci_support/linux_aarch64_r_base4.1.yaml
+++ b/.ci_support/linux_aarch64_r_base4.1.yaml
@@ -1,9 +1,13 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,17 +15,14 @@ channel_targets:
 cran_mirror:
 - https://cran.r-project.org
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
-libjpeg:
-- libjpeg-turbo
+- quay.io/condaforge/linux-anvil-aarch64
+libjpeg_turbo:
+- '2'
 pin_run_as_build:
   r-base:
     min_pin: x.x
     max_pin: x.x
 r_base:
-- '4.2'
+- '4.1'
 target_platform:
-- linux-64
-zip_keys:
-- - r_base
-  - libjpeg
+- linux-aarch64

--- a/.ci_support/linux_aarch64_r_base4.2.yaml
+++ b/.ci_support/linux_aarch64_r_base4.2.yaml
@@ -1,7 +1,11 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -11,17 +15,14 @@ channel_targets:
 cran_mirror:
 - https://cran.r-project.org
 docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
-libjpeg:
-- jpeg
+- quay.io/condaforge/linux-anvil-aarch64
+libjpeg_turbo:
+- '2'
 pin_run_as_build:
   r-base:
     min_pin: x.x
     max_pin: x.x
 r_base:
-- '4.1'
+- '4.2'
 target_platform:
-- linux-ppc64le
-zip_keys:
-- - r_base
-  - libjpeg
+- linux-aarch64

--- a/.ci_support/linux_ppc64le_r_base4.1.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.1.yaml
@@ -1,27 +1,24 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '14'
+- '12'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cran_mirror:
 - https://cran.r-project.org
-libjpeg:
-- libjpeg-turbo
-macos_machine:
-- x86_64-apple-darwin13.4.0
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
+libjpeg_turbo:
+- '2'
 pin_run_as_build:
   r-base:
     min_pin: x.x
     max_pin: x.x
 r_base:
-- '4.2'
+- '4.1'
 target_platform:
-- osx-64
-zip_keys:
-- - r_base
-  - libjpeg
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_r_base4.2.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.2.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -12,8 +12,8 @@ cran_mirror:
 - https://cran.r-project.org
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
-libjpeg:
-- libjpeg-turbo
+libjpeg_turbo:
+- '2'
 pin_run_as_build:
   r-base:
     min_pin: x.x
@@ -22,6 +22,3 @@ r_base:
 - '4.2'
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - r_base
-  - libjpeg

--- a/.ci_support/osx_64_r_base4.1.yaml
+++ b/.ci_support/osx_64_r_base4.1.yaml
@@ -3,15 +3,15 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cran_mirror:
 - https://cran.r-project.org
-libjpeg:
-- jpeg
+libjpeg_turbo:
+- '2'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:
@@ -22,6 +22,3 @@ r_base:
 - '4.1'
 target_platform:
 - osx-64
-zip_keys:
-- - r_base
-  - libjpeg

--- a/.ci_support/osx_64_r_base4.2.yaml
+++ b/.ci_support/osx_64_r_base4.2.yaml
@@ -1,23 +1,19 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '11'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cran_mirror:
 - https://cran.r-project.org
-docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
-libjpeg:
-- libjpeg-turbo
+libjpeg_turbo:
+- '2'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   r-base:
     min_pin: x.x
@@ -25,7 +21,4 @@ pin_run_as_build:
 r_base:
 - '4.2'
 target_platform:
-- linux-aarch64
-zip_keys:
-- - r_base
-  - libjpeg
+- osx-64

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -4,8 +4,8 @@ channel_targets:
 - conda-forge main
 cran_mirror:
 - https://cran.r-project.org
-libjpeg:
-- jpeg
+libjpeg_turbo:
+- '2'
 m2w64_c_compiler:
 - m2w64-toolchain
 pin_run_as_build:
@@ -16,6 +16,3 @@ r_base:
 - '4.1'
 target_platform:
 - win-64
-zip_keys:
-- - r_base
-  - libjpeg

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_aarch64_libjpegjpegr_base4.1 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+    - env: CONFIG=linux_aarch64_r_base4.1 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
       os: linux
       arch: arm64
       dist: focal
 
-    - env: CONFIG=linux_aarch64_libjpeglibjpeg-turbor_base4.2 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+    - env: CONFIG=linux_aarch64_r_base4.2 UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
       os: linux
       arch: arm64
       dist: focal

--- a/README.md
+++ b/README.md
@@ -45,59 +45,59 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_libjpegjpegr_base4.1</td>
+              <td>linux_64_r_base4.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1274&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libjpegjpegr_base4.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_r_base4.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_libjpeglibjpeg-turbor_base4.2</td>
+              <td>linux_64_r_base4.2</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1274&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_libjpeglibjpeg-turbor_base4.2" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_r_base4.2" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_libjpegjpegr_base4.1</td>
+              <td>linux_aarch64_r_base4.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1274&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_libjpegjpegr_base4.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_r_base4.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_libjpeglibjpeg-turbor_base4.2</td>
+              <td>linux_aarch64_r_base4.2</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1274&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_libjpeglibjpeg-turbor_base4.2" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_r_base4.2" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_libjpegjpegr_base4.1</td>
+              <td>linux_ppc64le_r_base4.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1274&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_libjpegjpegr_base4.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_r_base4.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_libjpeglibjpeg-turbor_base4.2</td>
+              <td>linux_ppc64le_r_base4.2</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1274&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_libjpeglibjpeg-turbor_base4.2" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_r_base4.2" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_libjpegjpegr_base4.1</td>
+              <td>osx_64_r_base4.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1274&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libjpegjpegr_base4.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_r_base4.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_libjpeglibjpeg-turbor_base4.2</td>
+              <td>osx_64_r_base4.2</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=1274&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_libjpeglibjpeg-turbor_base4.2" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-jpeg-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_r_base4.2" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,0 @@
-r_base:
-  - 4.1
-  - 4.2            # [not win]
-libjpeg:
-  - jpeg
-  - libjpeg-turbo  # [not win]
-zip_keys:
-  - r_base
-  - libjpeg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: true  # [win]
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/
@@ -33,11 +33,10 @@ requirements:
     - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base {{ r_base }}
-    - {{ libjpeg }}
+    - libjpeg-turbo
   run:
     - r-base {{ r_base }}
     - {{ native }}gcc-libs         # [win]
-    - {{ libjpeg }}
 
 test:
   commands:
@@ -56,18 +55,3 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge/r
-
-# Package: jpeg
-# Version: 0.1-8.1
-# Title: Read and write JPEG images
-# Author: Simon Urbanek <Simon.Urbanek@r-project.org>
-# Maintainer: Simon Urbanek <Simon.Urbanek@r-project.org>
-# Depends: R (>= 2.9.0)
-# Description: This package provides an easy and simple way to read, write and display bitmap images stored in the JPEG format. It can read and write both files and in-memory raw vectors.
-# License: GPL-2 | GPL-3
-# SystemRequirements: libjpeg
-# URL: http://www.rforge.net/jpeg/
-# Packaged: 2019-10-24 14:50:27 UTC; hornik
-# NeedsCompilation: yes
-# Repository: CRAN
-# Date/Publication: 2019-10-24 14:51:52 UTC


### PR DESCRIPTION
This removes the variant building workaround now that `r-base` is building with `libjpeg-turbo` for its `libjpeg`.

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
